### PR TITLE
Return errors applying filters as render errors

### DIFF
--- a/expressions/builders.go
+++ b/expressions/builders.go
@@ -22,7 +22,10 @@ func makeFilter(fn valueFn, name string, args []valueFn) valueFn {
 	return func(ctx Context) evaluator.Value {
 		result, err := ctx.ApplyFilter(name, fn, args)
 		if err != nil {
-			panic(err)
+			panic(FilterError{
+				FilterName: name,
+				Err:        err,
+			})
 		}
 		return evaluator.ValueOf(result)
 	}

--- a/expressions/expressions.go
+++ b/expressions/expressions.go
@@ -53,6 +53,8 @@ func (e expression) Evaluate(ctx Context) (out interface{}, err error) {
 				err = e
 			case UndefinedFilter:
 				err = e
+			case FilterError:
+				err = e
 			default:
 				panic(r)
 			}

--- a/expressions/expressions_test.go
+++ b/expressions/expressions_test.go
@@ -1,6 +1,7 @@
 package expressions
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -133,6 +134,10 @@ func TestEvaluateString(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = EvaluateString("1 | undefined_filter", ctx)
+	require.Error(t, err)
+
+	cfg.AddFilter("error", func(input interface{}) (string, error) { return "", errors.New("test error") })
+	_, err = EvaluateString("1 | error", ctx)
 	require.Error(t, err)
 }
 

--- a/expressions/filters.go
+++ b/expressions/filters.go
@@ -21,6 +21,16 @@ func (e UndefinedFilter) Error() string {
 	return fmt.Sprintf("undefined filter %q", string(e))
 }
 
+// FilterError is the error returned by a filter when it is applied
+type FilterError struct {
+	FilterName string
+	Err        error
+}
+
+func (e FilterError) Error() string {
+	return fmt.Sprintf("error applying filter %q (%q)", e.FilterName, e.Err)
+}
+
 type valueFn func(Context) evaluator.Value
 
 // AddFilter adds a filter to the filter dictionary.


### PR DESCRIPTION
When a Filter returns an error as its second argument it generates a panic with the error.

I have changed this behaviour so that the error is returned from the RenderAndPass function.

For example, if there is a filter called `toTitle` that returns "test error" as its error, the error returned will be `'Liquid error: error applying filter "toTitle" ("test error") in {{ "test message" | toTitle }}'`.

Apologies if panicing in this case is the expected behaviour and this was done intentionally, I can always just catch the panic when I call the Render step, I just think this way is more elegant.