### PR TITLE
Add setting to customise delimiters

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -97,3 +97,10 @@ func (e *Engine) ParseAndRenderString(source string, b Bindings) (string, Source
 	}
 	return string(bs), nil
 }
+
+// SetDelims sets the delimiters for parsing the template. This sets the character characters that
+// are used for '{', '}' and '%'
+func (e *Engine) SetDelims(objectLeft, objectRight, tag byte) *Engine {
+	e.cfg.Delims = []byte{objectLeft, objectRight, tag}
+	return e
+}

--- a/engine.go
+++ b/engine.go
@@ -98,9 +98,12 @@ func (e *Engine) ParseAndRenderString(source string, b Bindings) (string, Source
 	return string(bs), nil
 }
 
-// SetDelims sets the delimiters for parsing the template. This sets the character characters that
-// are used for '{', '}' and '%'
-func (e *Engine) SetDelims(objectLeft, objectRight, tag byte) *Engine {
-	e.cfg.Delims = []byte{objectLeft, objectRight, tag}
+// Delims sets the action delimiters to the specified strings, to be used in subsequent calls to
+// ParseTemplate, ParseTemplateLocation, ParseAndRender, or ParseAndRenderString. An empty delimiter
+// stands for the corresponding default: { and } for the general delimiters and % for the tag
+// modifier. This results in objects being delimited with "{{" and "}}" and tags "{%" and "%}". The
+// return value is the engine, so calls can be chained.
+func (e *Engine) Delims(left, right, tag byte) *Engine {
+	e.cfg.Delims = []byte{left, right, tag}
 	return e
 }

--- a/engine.go
+++ b/engine.go
@@ -100,10 +100,8 @@ func (e *Engine) ParseAndRenderString(source string, b Bindings) (string, Source
 
 // Delims sets the action delimiters to the specified strings, to be used in subsequent calls to
 // ParseTemplate, ParseTemplateLocation, ParseAndRender, or ParseAndRenderString. An empty delimiter
-// stands for the corresponding default: { and } for the general delimiters and % for the tag
-// modifier. This results in objects being delimited with "{{" and "}}" and tags "{%" and "%}". The
-// return value is the engine, so calls can be chained.
-func (e *Engine) Delims(left, right, tag byte) *Engine {
-	e.cfg.Delims = []byte{left, right, tag}
+// stands for the corresponding default: objectLeft = {{, objectRight = }}, tagLeft = {% , tagRight = %}
+func (e *Engine) Delims(objectLeft, objectRight, tagLeft, tagRight string) *Engine {
+	e.cfg.Delims = []string{objectLeft, objectRight, tagLeft, tagRight}
 	return e
 }

--- a/parser/config.go
+++ b/parser/config.go
@@ -6,7 +6,7 @@ import "github.com/osteele/liquid/expressions"
 type Config struct {
 	expressions.Config
 	Grammar Grammar
-	Delims  []byte
+	Delims  []string
 }
 
 // NewConfig creates a parser Config.

--- a/parser/config.go
+++ b/parser/config.go
@@ -6,6 +6,7 @@ import "github.com/osteele/liquid/expressions"
 type Config struct {
 	expressions.Config
 	Grammar Grammar
+	Delims  []byte
 }
 
 // NewConfig creates a parser Config.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,7 +10,7 @@ import (
 
 // Parse parses a source template. It returns an AST root, that can be compiled and evaluated.
 func (c Config) Parse(source string, loc SourceLoc) (ASTNode, Error) {
-	tokens := Scan(source, loc)
+	tokens := Scan(source, loc, c.Delims)
 	return c.parseTokens(tokens)
 }
 

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -98,3 +98,63 @@ func TestScan_ws(t *testing.T) {
 		})
 	}
 }
+
+var scannerCountTestsDelims = []struct {
+	in  string
+	len int
+}{
+	{`<* tag arg *>`, 1},
+	{`<* tag arg *><* tag *>`, 2},
+	{`<* tag arg *><* tag arg *><* tag *>`, 3},
+	// {`<* tag *><* tag *>`, 2}, // Currently failing
+	// {`<* tag arg *><* tag arg *><* tag *><* tag *>`, 4}, // Currently failing
+	{`<< expr >>`, 1},
+	{`<< expr arg >>`, 1},
+	{`<< expr >><< expr >>`, 2},
+	{`<< expr arg >><< expr arg >>`, 2},
+}
+
+func TestScan_delims(t *testing.T) {
+	scan := func(src string) []Token { return Scan(src, SourceLoc{}, []byte{'<', '>', '*'}) }
+	tokens := scan("12")
+	require.NotNil(t, tokens)
+	require.Len(t, tokens, 1)
+	require.Equal(t, TextTokenType, tokens[0].Type)
+	require.Equal(t, "12", tokens[0].Source)
+
+	tokens = scan("<<obj>>")
+	require.NotNil(t, tokens)
+	require.Len(t, tokens, 1)
+	require.Equal(t, ObjTokenType, tokens[0].Type)
+	require.Equal(t, "obj", tokens[0].Args)
+
+	tokens = scan("<< obj >>")
+	require.NotNil(t, tokens)
+	require.Len(t, tokens, 1)
+	require.Equal(t, ObjTokenType, tokens[0].Type)
+	require.Equal(t, "obj", tokens[0].Args)
+
+	tokens = scan("<*tag args*>")
+	require.NotNil(t, tokens)
+	require.Len(t, tokens, 1)
+	require.Equal(t, TagTokenType, tokens[0].Type)
+	require.Equal(t, "tag", tokens[0].Name)
+	require.Equal(t, "args", tokens[0].Args)
+
+	tokens = scan("<* tag args *>")
+	require.NotNil(t, tokens)
+	require.Len(t, tokens, 1)
+	require.Equal(t, TagTokenType, tokens[0].Type)
+	require.Equal(t, "tag", tokens[0].Name)
+	require.Equal(t, "args", tokens[0].Args)
+
+	tokens = scan("pre<* tag args *>mid<< object >>post")
+	require.Equal(t, `[TextTokenType{"pre"} TagTokenType{Tag:"tag", Args:"args"} TextTokenType{"mid"} ObjTokenType{"object"} TextTokenType{"post"}]`, fmt.Sprint(tokens))
+
+	for i, test := range scannerCountTestsDelims {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			tokens := scan(test.in)
+			require.Len(t, tokens, test.len)
+		})
+	}
+}

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -23,7 +23,7 @@ var scannerCountTests = []struct {
 }
 
 func TestScan(t *testing.T) {
-	scan := func(src string) []Token { return Scan(src, SourceLoc{}) }
+	scan := func(src string) []Token { return Scan(src, SourceLoc{}, nil) }
 	tokens := scan("12")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
@@ -69,7 +69,7 @@ func TestScan(t *testing.T) {
 
 func TestScan_ws(t *testing.T) {
 	// whitespace control
-	scan := func(src string) []Token { return Scan(src, SourceLoc{}) }
+	scan := func(src string) []Token { return Scan(src, SourceLoc{}, nil) }
 
 	wsTests := []struct {
 		in, expect  string

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -103,52 +103,54 @@ var scannerCountTestsDelims = []struct {
 	in  string
 	len int
 }{
-	{`<* tag arg *>`, 1},
-	{`<* tag arg *><* tag *>`, 2},
-	{`<* tag arg *><* tag arg *><* tag *>`, 3},
-	// {`<* tag *><* tag *>`, 2}, // Currently failing
-	// {`<* tag arg *><* tag arg *><* tag *><* tag *>`, 4}, // Currently failing
-	{`<< expr >>`, 1},
-	{`<< expr arg >>`, 1},
-	{`<< expr >><< expr >>`, 2},
-	{`<< expr arg >><< expr arg >>`, 2},
+	{`TAG*LEFT tag arg TAG!RIGHT`, 1},
+	{`TAG*LEFT tag arg TAG!RIGHTTAG*LEFT tag TAG!RIGHT`, 2},
+	{`TAG*LEFT tag arg TAG!RIGHTTAG*LEFT tag arg TAG!RIGHTTAG*LEFT tag TAG!RIGHT`, 3},
+	{`TAG*LEFT tag TAG!RIGHTTAG*LEFT tag TAG!RIGHT`, 2},
+	{`TAG*LEFT tag arg TAG!RIGHTTAG*LEFT tag arg TAG!RIGHTTAG*LEFT tag TAG!RIGHTTAG*LEFT tag TAG!RIGHT`, 4},
+	{`OBJECT@LEFT expr OBJECT#RIGHT`, 1},
+	{`OBJECT@LEFT expr arg OBJECT#RIGHT`, 1},
+	{`OBJECT@LEFT expr OBJECT#RIGHTOBJECT@LEFT expr OBJECT#RIGHT`, 2},
+	{`OBJECT@LEFT expr arg OBJECT#RIGHTOBJECT@LEFT expr arg OBJECT#RIGHT`, 2},
 }
 
 func TestScan_delims(t *testing.T) {
-	scan := func(src string) []Token { return Scan(src, SourceLoc{}, []byte{'<', '>', '*'}) }
+	scan := func(src string) []Token {
+		return Scan(src, SourceLoc{}, []string{"OBJECT@LEFT", "OBJECT#RIGHT", "TAG*LEFT", "TAG!RIGHT"})
+	}
 	tokens := scan("12")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
 	require.Equal(t, TextTokenType, tokens[0].Type)
 	require.Equal(t, "12", tokens[0].Source)
 
-	tokens = scan("<<obj>>")
+	tokens = scan("OBJECT@LEFTobjOBJECT#RIGHT")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
 	require.Equal(t, ObjTokenType, tokens[0].Type)
 	require.Equal(t, "obj", tokens[0].Args)
 
-	tokens = scan("<< obj >>")
+	tokens = scan("OBJECT@LEFT obj OBJECT#RIGHT")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
 	require.Equal(t, ObjTokenType, tokens[0].Type)
 	require.Equal(t, "obj", tokens[0].Args)
 
-	tokens = scan("<*tag args*>")
+	tokens = scan("TAG*LEFTtag argsTAG!RIGHT")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
 	require.Equal(t, TagTokenType, tokens[0].Type)
 	require.Equal(t, "tag", tokens[0].Name)
 	require.Equal(t, "args", tokens[0].Args)
 
-	tokens = scan("<* tag args *>")
+	tokens = scan("TAG*LEFT tag args TAG!RIGHT")
 	require.NotNil(t, tokens)
 	require.Len(t, tokens, 1)
 	require.Equal(t, TagTokenType, tokens[0].Type)
 	require.Equal(t, "tag", tokens[0].Name)
 	require.Equal(t, "args", tokens[0].Args)
 
-	tokens = scan("pre<* tag args *>mid<< object >>post")
+	tokens = scan("preTAG*LEFT tag args TAG!RIGHTmidOBJECT@LEFT object OBJECT#RIGHTpost")
 	require.Equal(t, `[TextTokenType{"pre"} TagTokenType{Tag:"tag", Args:"args"} TextTokenType{"mid"} ObjTokenType{"object"} TextTokenType{"post"}]`, fmt.Sprint(tokens))
 
 	for i, test := range scannerCountTestsDelims {


### PR DESCRIPTION
I would like to be able to customise the delimiters I use in templating (this is intended as an analog of https://golang.org/pkg/text/template/#Template.Delims).

This PR has the following problems
1. Delimiters is a byte array to limit them to single ASCII characters
2. The tag delimiters are formed using the objectLeft and objectRight argument, I would like to specify all 4 combinations completely, e.g., "<<", ">>", "<%", "%>".
3. I think moving compilation of the `tokenMatcher` regex into the function call will dramatically slow things down.
4. There are no tests.
I did it like this so I didn't have to change the existing code much.

I am happy to continue work on this, but I'm lodging a PR to see if you're willing to accept this sort of functionality, if I'm going about implementing in the right way, and to check if I haven't missed some other locations where the delimiters are hardcoded.
