### PR TITLE
Properly handle variadic functions.

### DIFF
--- a/values/call.go
+++ b/values/call.go
@@ -47,7 +47,11 @@ func convertCallArguments(fn reflect.Value, args []interface{}) (results []refle
 		return nil, &CallParityError{NumArgs: len(args), NumParams: rt.NumIn()}
 	}
 	if rt.IsVariadic() {
-		results = make([]reflect.Value, len(args))
+		numArgs, minArgs := len(args), rt.NumIn()-1
+		if numArgs < minArgs {
+			numArgs = minArgs
+		}
+		results = make([]reflect.Value, numArgs)
 	} else {
 		results = make([]reflect.Value, rt.NumIn())
 	}
@@ -67,8 +71,9 @@ func convertCallArguments(fn reflect.Value, args []interface{}) (results []refle
 			results[i] = reflect.ValueOf(MustConvert(arg, typ))
 		}
 	}
+
 	// create zeros and default functions for parameters without arguments
-	for i := len(args); i < rt.NumIn(); i++ {
+	for i := len(args); i < len(results); i++ {
 		typ := rt.In(i)
 		switch {
 		case isDefaultFunctionType(typ):

--- a/values/call_test.go
+++ b/values/call_test.go
@@ -54,3 +54,25 @@ func TestCall_optional(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "5,10.", value)
 }
+
+func TestCall_variadic(t *testing.T) {
+	fn := func(sep func(string) string, args ...string) string {
+		return "[" + strings.Join(args, sep(",")) + "]"
+	}
+
+	value, err := Call(reflect.ValueOf(fn), []interface{}{",", "a"})
+	require.NoError(t, err)
+	require.Equal(t, "[a]", value)
+
+	value, err = Call(reflect.ValueOf(fn), []interface{}{",", "a", "b"})
+	require.NoError(t, err)
+	require.Equal(t, "[a,b]", value)
+
+	value, err = Call(reflect.ValueOf(fn), []interface{}{","})
+	require.NoError(t, err)
+	require.Equal(t, "[]", value)
+
+	value, err = Call(reflect.ValueOf(fn), []interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, "[]", value)
+}


### PR DESCRIPTION
This commit addresses two issues:

1. For variadic functions 'convertCallArguments' was allocating exactly
   'len(args)' arguments, which might be less than required, as a result
   zero/default filling loop would panic with out of bounds error.

2. Even if we correctly allocate a proper amount of arguments, zero/default
   filling loop doesn't handle special variadic function type case, when last
   argument has a slice type and reflect API expects plain values as arguments.
   But actually we don't need that, because it's okay to omit variadic values
   altogether, hence the total amount of allocated arguments is
   max(len(args), rt.NumIn()-1).

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
