### PR TITLE
Add support to cached templates

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -110,3 +110,19 @@ func (e *Engine) Delims(objectLeft, objectRight, tagLeft, tagRight string) *Engi
 	e.cfg.Delims = []string{objectLeft, objectRight, tagLeft, tagRight}
 	return e
 }
+
+// ParseTemplateAndCache is the same as ParseTemplateLocation, except that the
+// source location is used for error reporting and for the {% include %} tag.
+// If parsing is successful, provided source is then cached, and can be retrieved
+// by {% include %} tags, as long as there is not a real file in the provided path.
+//
+// The path and line number are used for error reporting.
+// The path is also the reference for relative pathnames in the {% include %} tag.
+func (e *Engine) ParseTemplateAndCache(source []byte, path string, line int) (*Template, SourceError) {
+	t, err := e.ParseTemplateLocation(source, path, line)
+	if err != nil {
+		return t, err
+	}
+	e.cfg.Cache[path] = source
+	return t, err
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -92,3 +92,19 @@ func BenchmarkEngine_Parse(b *testing.B) {
 		engine.ParseTemplate(s)
 	}
 }
+
+func TestEngine_ParseTemplateAndCache(t *testing.T) {
+	// Given two templates...
+	templateA := []byte("Foo")
+	templateB := []byte(`{% include "template_a.html" %}, Bar`)
+
+	// Cache the first
+	eng := NewEngine()
+	_, err := eng.ParseTemplateAndCache(templateA, "template_a.html", 1)
+	require.NoError(t, err)
+
+	// ...and execute the second.
+	result, err := eng.ParseAndRender(templateB, Bindings{})
+	require.NoError(t, err)
+	require.Equal(t, string(result), "Foo, Bar")
+}

--- a/render/config.go
+++ b/render/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	parser.Config
 	grammar
+	Cache map[string][]byte
 }
 
 type grammar struct {
@@ -21,5 +22,5 @@ func NewConfig() Config {
 		tags:      map[string]TagCompiler{},
 		blockDefs: map[string]*blockSyntax{},
 	}
-	return Config{parser.NewConfig(g), g}
+	return Config{Config: parser.NewConfig(g), grammar: g, Cache: map[string][]byte{}}
 }

--- a/tags/include_tag_test.go
+++ b/tags/include_tag_test.go
@@ -58,3 +58,18 @@ func TestIncludeTag_file_not_found_error(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err.Cause()))
 }
+
+func TestIncludeTag_cached_value_handling(t *testing.T) {
+	config := render.NewConfig()
+	// foo.html does not exist on testdata.
+	config.Cache["testdata/foo.html"] = []byte("bar")
+	loc := parser.SourceLoc{Pathname: "testdata/include_source.html", LineNo: 1}
+	AddStandardTags(config)
+
+	root, err := config.Compile(`{% include "foo.html" %}`, loc)
+	require.NoError(t, err)
+	buf := new(bytes.Buffer)
+	err = render.Render(root, buf, includeTestBindings, config)
+	require.NoError(t, err)
+	require.Equal(t, "bar", strings.TrimSpace(buf.String()))
+}


### PR DESCRIPTION
Hi there!
I'm a bit uncomfortable about opening this PR since this behaviour is not part of Shopify's API. So please feel free to disregard this.

I found myself using this package with a "virtualised" file system, in which templates are embedded into my binary, rather than being available in directories. This adds a new `ParseTemplateAndCache` method to `Engine` that caches a provided template, and allows `{% include %}` tags to use them, in case the file is not present in disk.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
