### PR TITLE
🐛 Fix MaxUint32 assignment to platform int

### DIFF
--- a/expressions/y.go
+++ b/expressions/y.go
@@ -664,7 +664,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line expressions.y:105
 		{
-			yyVAL.loopmods = loopModifiers{Cols: math.MaxUint32}
+			yyVAL.loopmods = loopModifiers{Cols: math.MaxInt32}
 		}
 	case 21:
 		yyDollar = yyS[yypt-2 : yypt+1]


### PR DESCRIPTION
This fixes an issue where math.MaxUint32 is assigned to a platform
dependent int type. This works on 64-bit platforms without issue due to
there being plenty of space. On 32-bit platforms this is wrong and will
not compile as math.MaxUint32 > math.MaxInt32.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
