### PR TITLE
Expose the template ast

### DIFF
--- a/template.go
+++ b/template.go
@@ -24,6 +24,12 @@ func newTemplate(cfg *render.Config, source []byte, path string, line int) (*Tem
 	return &Template{root, cfg}, nil
 }
 
+// GetRoot returns the root node of the abstract syntax tree (AST) representing
+// the parsed template.
+func (t *Template) GetRoot() render.Node {
+	return t.root
+}
+
 // Render executes the template with the specified variable bindings.
 func (t *Template) Render(vars Bindings) ([]byte, SourceError) {
 	buf := new(bytes.Buffer)

--- a/template_test.go
+++ b/template_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTemplate_GetRoot(t *testing.T) {
+	root := &render.SeqNode{}
+	tmpl := Template{root: root}
+	require.Same(t, root, tmpl.GetRoot())
+}
+
 func TestTemplate_RenderString(t *testing.T) {
 	engine := NewEngine()
 	tpl, err := engine.ParseTemplate([]byte(`{{ "hello world" | capitalize }}`))


### PR DESCRIPTION
Sometimes a consumer of a template needs to know what objects were used. In my case, a template can reference secret values from a secret store vault and instead of passing all possible secrets to the template only to render two of them, we use the ast to determine which are used and only retrieve those values from the vault before rendering the template.

Exposing the ast allows us to use the liquid APIs just like normal, without having to jump through hoops to build the ast ourselves using the other types exported in this library.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks. N/A
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify. N/A
