### PR TITLE
Example: List variables used in template

### DIFF
--- a/engine_examples_test.go
+++ b/engine_examples_test.go
@@ -3,6 +3,7 @@ package liquid
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/osteele/liquid/render"
@@ -22,6 +23,43 @@ func Example() {
 	}
 	fmt.Println(out)
 	// Output: <h1>Introduction</h1>
+}
+
+// List the variable names used in a template
+func Example_listTemplateVariables() {
+	engine := NewEngine()
+	tmpl, err := engine.ParseString(`Name: {{Name}}<br/>Age: {{Age}}`)
+	if err != nil {
+		panic(err)
+	}
+
+	// Find variable names
+	vars := map[string]struct{}{}
+	var findVariables func(curNode render.Node)
+	findVariables = func(curNode render.Node) {
+		switch v := curNode.(type) {
+		case *render.SeqNode:
+			for _, childNode := range v.Children {
+				findVariables(childNode)
+			}
+		case *render.ObjectNode:
+			vars[v.Args] = struct{}{}
+		}
+	}
+
+	findVariables(tmpl.GetRoot())
+
+	// Sort variable names
+	varNames := make([]string, 0, len(vars))
+	for name := range vars {
+		varNames = append(varNames, name)
+	}
+	sort.Strings(varNames)
+
+	// Print list of used variables
+	fmt.Printf("The template uses the following variables: %s\n", strings.Join(varNames, ", "))
+
+	// Output: The template uses the following variables: Age, Name
 }
 
 func ExampleEngine_ParseAndRenderString() {


### PR DESCRIPTION
Add a godoc example that demonstrates how to list variable names used.

I realized when I wrote this example that it works great for us since we don't use expressions in templates like `{{ myvar | capitalize }}`. It doesn't work for expressions but it could if I exported a few more values so that I can get the bindings used in the expression context.

I can submit a PR to add a few more getter functions to make this example work for more templates if that's something you would consider merging?

Below is a screenshot of the example rendered in godoc
<img width="550" alt="Screen Shot 2022-02-13 at 9 08 59 PM" src="https://user-images.githubusercontent.com/1368985/153793694-0b33868f-1770-4d23-8cfa-59ca1c532380.png">

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks. (NA)
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify. (NA)
