### PR TITLE
Allow range expression as general expressions (not only loops)

### DIFF
--- a/tags/iteration_tags_test.go
+++ b/tags/iteration_tags_test.go
@@ -85,6 +85,7 @@ var iterationTests = []struct{ in, expected string }{
 	// range
 	{`{% for i in (3 .. 5) %}{{i}}.{% endfor %}`, "3.4.5."},
 	{`{% for i in (3..5) %}{{i}}.{% endfor %}`, "3.4.5."},
+	{`{% assign l = (3..5) %}{% for i in l %}{{i}}.{% endfor %}`, "3.4.5."},
 
 	// tablerow
 	{`{% tablerow product in products %}{{ product }}{% endtablerow %}`,

--- a/tags/standard_tags_test.go
+++ b/tags/standard_tags_test.go
@@ -24,6 +24,7 @@ var tagTests = []struct{ in, expected string }{
 	// variable tags
 	{`{% assign av = 1 %}{{ av }}`, "1"},
 	{`{% assign av = obj.a %}{{ av }}`, "1"},
+	{`{% assign av = (1..5) %}{{ av }}`, "{1 5}"},
 	{`{% capture x %}captured{% endcapture %}{{ x }}`, "captured"},
 
 	// TODO research whether Liquid requires matching interior tags

--- a/values/convert.go
+++ b/values/convert.go
@@ -202,6 +202,8 @@ func Convert(value interface{}, typ reflect.Type) (interface{}, error) { // noli
 				result = reflect.Append(result, ev.Convert(et))
 			}
 			return result.Interface(), nil
+		} else if r, ok := value.(Range); ok {
+			return r.AsArray(), nil
 		}
 		switch rv.Kind() {
 		case reflect.Array, reflect.Slice:

--- a/values/convert_test.go
+++ b/values/convert_test.go
@@ -84,6 +84,8 @@ var convertTests = []struct {
 	{yaml.MapSlice{{Key: "a", Value: 1}}, map[string]string{"a": "1"}},
 	{yaml.MapSlice{{Key: "a", Value: nil}}, map[string]interface{}{"a": nil}},
 	{yaml.MapSlice{{Key: nil, Value: 1}}, map[interface{}]string{nil: "1"}},
+	{Range{1, 5}, []interface{}{1, 2, 3, 4, 5}},
+	{Range{0, 0}, []interface{}{0}},
 	// {"March 14, 2016", time.Now(), timeMustParse("2016-03-14T00:00:00Z")},
 	{redConvertible{}, "red"},
 }

--- a/values/range.go
+++ b/values/range.go
@@ -15,3 +15,12 @@ func (r Range) Len() int { return r.e + 1 - r.b }
 
 // Index is in the iteration interface
 func (r Range) Index(i int) interface{} { return r.b + i }
+
+// AsArray converts the range into an array.
+func (r Range) AsArray() []interface{} {
+	a := make([]interface{}, 0, r.Len())
+	for i := r.b; i <= r.e; i++ {
+		a = append(a, i)
+	}
+	return a
+}


### PR DESCRIPTION
Currently the range expression `(start..end)` is only supported in loops. This PR makes is possible to use it as a general expression e.g.:

```liquid
{% assign l = (1..5) | reverse %}
{% for i in l %}
{{ i -}}
{% endfor %}
```

results in:

```
5
4
3
2
1
```

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.

