### PR TITLE
Expose the template lexical environment

### DIFF
--- a/render/context.go
+++ b/render/context.go
@@ -12,6 +12,8 @@ import (
 
 // Context provides the rendering context for a tag renderer.
 type Context interface {
+	// Bindings returns the current lexical environment.
+	Bindings() map[string]interface{}
 	// Get retrieves the value of a variable from the current lexical environment.
 	Get(name string) interface{}
 	// Errorf creates a SourceError, that includes the source location.
@@ -73,6 +75,11 @@ func (c rendererContext) Evaluate(expr expressions.Expression) (out interface{},
 // EvaluateString evaluates an expression within the template context.
 func (c rendererContext) EvaluateString(source string) (out interface{}, err error) {
 	return expressions.EvaluateString(source, expressions.NewContext(c.ctx.bindings, c.ctx.config.Config.Config))
+}
+
+// Bindings returns the current lexical environment.
+func (c rendererContext) Bindings() map[string]interface{} {
+	return c.ctx.bindings
 }
 
 // Get gets a variable value within an evaluation context.


### PR DESCRIPTION
I like to implement a tag, that require the full lexical context (bindings) to be copied. Currently the `render.Context` interface exposes the `Get` and `Set` function to manipulate the bindings, but those don't let me iterate over the whole thing. Thus, this PR adds a function that returns the full bindings. Usage example:

```go
func (tc tagContext) myTag(rc render.Context) (s string, err error) {
	bindings := rc.Bindings()
	...
}
```

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
