### PR TITLE
Fix map filter with slice of structs

### DIFF
--- a/filters/standard_filters.go
+++ b/filters/standard_filters.go
@@ -47,9 +47,11 @@ func AddStandardFilters(fd FilterDictionary) { // nolint: gocyclo
 		return append(append(result, a...), b...)
 	})
 	fd.AddFilter("join", joinFilter)
-	fd.AddFilter("map", func(a []map[string]interface{}, key string) (result []interface{}) {
+	fd.AddFilter("map", func(a []interface{}, key string) (result []interface{}) {
+		keyValue := values.ValueOf(key)
 		for _, obj := range a {
-			result = append(result, obj[key])
+			value := values.ValueOf(obj)
+			result = append(result, value.PropertyValue(keyValue).Interface())
 		}
 		return result
 	})

--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -60,6 +60,8 @@ var filterTests = []struct {
 	{`map_slice_dup | join`, `a a b`},
 	{`map_slice_dup | uniq | join`, `a b`},
 
+	{`struct_slice | map: "str" | join`, `a b c`},
+
 	// date filters
 	{`article.published_at | date`, "Fri, Jul 17, 15"},
 	{`article.published_at | date: "%a, %b %d, %y"`, "Fri, Jul 17, 15"},
@@ -236,6 +238,13 @@ var filterTestBindings = map[string]interface{}{
 		{"name": "page 5", "category": "sports"},
 		{"name": "page 6"},
 		{"name": "page 7", "category": "technology"},
+	},
+	"struct_slice": []struct {
+		Str string `liquid:"str"`
+	}{
+		{Str: "a"},
+		{Str: "b"},
+		{Str: "c"},
 	},
 }
 


### PR DESCRIPTION
The previous map implementation worked only for slices of maps. By using the library's `values` package this implementation should work with all compatible types.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes. (at least on modified files)
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.