### PR TITLE
Fix slice

### DIFF
--- a/filters/standard_filters.go
+++ b/filters/standard_filters.go
@@ -148,24 +148,55 @@ func AddStandardFilters(fd FilterDictionary) { // nolint: gocyclo
 		return strings.Replace(s, old, new, 1)
 	})
 	fd.AddFilter("sort_natural", sortNaturalFilter)
-	fd.AddFilter("slice", func(s string, start int, length func(int) int) string {
-		// Work on runes, not chars
-		runes := []rune(s)
-		n := length(1)
-		if start < 0 {
-			start = len(runes) + start
+	fd.AddFilter("slice", func(v interface{}, start int, length func(int) int) interface{} {
+		// Are we in the []byte case? Transform []byte to string
+		if b, ok := v.([]byte); ok {
+			v = string(b)
+		}
+		// Are we in the string case?
+		if s, ok := v.(string); ok {
+			// Work on runes, not chars
+			runes := []rune(s)
+			n := length(1)
 			if start < 0 {
-				start = 0
+				start = len(runes) + start
+				if start < 0 {
+					start = 0
+				}
+			}
+			if start > len(runes) {
+				start = len(runes)
+			}
+			end := start + n
+			if end > len(runes) {
+				end = len(runes)
+			}
+			return string(runes[start:end])
+		}
+		// Are we in the slice case?
+		// A type test cannot suffice because []T and []U are different types, so we must use conversion.
+		var slice []interface{}
+		if sliceIface, err := values.Convert(v, reflect.TypeOf(slice)); err == nil {
+			var ok bool
+			if slice, ok = sliceIface.([]interface{}); ok {
+				n := length(1)
+				if start < 0 {
+					start = len(slice) + start
+					if start < 0 {
+						start = 0
+					}
+				}
+				if start > len(slice) {
+					start = len(slice)
+				}
+				end := start + n
+				if end > len(slice) {
+					end = len(slice)
+				}
+				return slice[start:end]
 			}
 		}
-		if start > len(runes) {
-			start = len(runes)
-		}
-		end := start + n
-		if end > len(runes) {
-			end = len(runes)
-		}
-		return string(runes[start:end])
+		return nil
 	})
 	fd.AddFilter("split", splitFilter)
 	fd.AddFilter("strip_html", func(s string) string {

--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -116,6 +116,10 @@ var filterTests = []struct {
 	{`"白鵬翔" | slice: -100`, "白"},
 	{`"白鵬翔" | slice: -100, 200`, "白鵬翔"},
 	{`">` + strings.Repeat(".", 10000) + `<" | slice: 1, 10000`, strings.Repeat(".", 10000)},
+	{`"a,b,c" | split: "," | slice: -1 | join`, "c"},
+	{`"a,b,c" | split: "," | slice: 1, 1 | join`, "b"},
+	{`"a,b,c" | split: "," | slice: 0, 2 | join`, "a b"},
+	{`"a,b,c" | split: "," | slice: 1, 2 | join`, "b c"},
 
 	{`"a/b/c" | split: '/' | join: '-'`, "a-b-c"},
 	{`"a/b/" | split: '/' | join: '-'`, "a-b"},

--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -101,6 +101,11 @@ var filterTests = []struct {
 	{`"Liquid" | slice: 2`, "q"},
 	{`"Liquid" | slice: 2, 5`, "quid"},
 	{`"Liquid" | slice: -3, 2`, "ui"},
+	{`"白鵬翔" | slice: 0`, "白"},
+	{`"白鵬翔" | slice: 1`, "鵬"},
+	{`"白鵬翔" | slice: 2`, "翔"},
+	{`"白鵬翔" | slice: 0, 2`, "白鵬"},
+	{`"白鵬翔" | slice: 1, 2`, "鵬翔"},
 
 	{`"a/b/c" | split: '/' | join: '-'`, "a-b-c"},
 	{`"a/b/" | split: '/' | join: '-'`, "a-b"},

--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,11 +102,20 @@ var filterTests = []struct {
 	{`"Liquid" | slice: 2`, "q"},
 	{`"Liquid" | slice: 2, 5`, "quid"},
 	{`"Liquid" | slice: -3, 2`, "ui"},
+	{`"Liquid" | slice: 2, 100`, "quid"},
+	{`"Liquid" | slice: 100`, ""},
+	{`"Liquid" | slice: 100, 200`, ""},
+	{`"Liquid" | slice: -100`, "L"},
+	{`"Liquid" | slice: -100, 200`, "Liquid"},
 	{`"白鵬翔" | slice: 0`, "白"},
 	{`"白鵬翔" | slice: 1`, "鵬"},
 	{`"白鵬翔" | slice: 2`, "翔"},
 	{`"白鵬翔" | slice: 0, 2`, "白鵬"},
 	{`"白鵬翔" | slice: 1, 2`, "鵬翔"},
+	{`"白鵬翔" | slice: 100, 200`, ""},
+	{`"白鵬翔" | slice: -100`, "白"},
+	{`"白鵬翔" | slice: -100, 200`, "白鵬翔"},
+	{`">` + strings.Repeat(".", 10000) + `<" | slice: 1, 10000`, strings.Repeat(".", 10000)},
 
 	{`"a/b/c" | split: '/' | join: '-'`, "a-b-c"},
 	{`"a/b/" | split: '/' | join: '-'`, "a-b"},


### PR DESCRIPTION
`slice` was broken with an offset or length above 1000.
Shopify documents that `slice` supports arrays in addition to strings; I added support for working on slices.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes. (at least on modified files)
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
