### PR TITLE
Add support for strict variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ These features of Shopify Liquid aren't implemented:
   }}`. [[Issue #42](https://github.com/osteele/liquid/issues/42)]
 - Warn and lax [error modes](https://github.com/shopify/liquid#error-modes).
 - Non-strict filters. An undefined filter is currently an error.
-- Strict variables. An undefined variable is not an error.
 
 ### Drops
 

--- a/cmd/liquid/main.go
+++ b/cmd/liquid/main.go
@@ -21,12 +21,13 @@ import (
 
 // for testing
 var (
-	stderr   io.Writer              = os.Stderr
-	stdout   io.Writer              = os.Stdout
-	stdin    io.Reader              = os.Stdin
-	exit     func(int)              = os.Exit
-	env      func() []string        = os.Environ
-	bindings map[string]interface{} = map[string]interface{}{}
+	stderr     io.Writer              = os.Stderr
+	stdout     io.Writer              = os.Stdout
+	stdin      io.Reader              = os.Stdin
+	exit       func(int)              = os.Exit
+	env        func() []string        = os.Environ
+	bindings   map[string]interface{} = map[string]interface{}{}
+	strictVars bool
 )
 
 func main() {
@@ -41,6 +42,7 @@ func main() {
 
 	var bindEnvs bool
 	cmdLine.BoolVar(&bindEnvs, "env", false, "bind environment variables")
+	cmdLine.BoolVar(&strictVars, "strict", false, "enable strict variable mode in templates")
 
 	err = cmdLine.Parse(os.Args[1:])
 	if err != nil {
@@ -86,7 +88,11 @@ func render() error {
 		return err
 	}
 
-	tpl, err := liquid.NewEngine().ParseTemplate(buf)
+	e := liquid.NewEngine()
+	if strictVars {
+		e.StrictVariables()
+	}
+	tpl, err := e.ParseTemplate(buf)
 	if err != nil {
 		return err
 	}

--- a/cmd/liquid/main_test.go
+++ b/cmd/liquid/main_test.go
@@ -58,6 +58,7 @@ func TestMain(t *testing.T) {
 	main()
 	require.True(t, envCalled)
 	require.Equal(t, "Hello, World!", buf.String())
+	bindings = make(map[string]interface{})
 
 	// filename
 	stdin = os.Stdin
@@ -72,6 +73,17 @@ func TestMain(t *testing.T) {
 	exitCode := 0
 	exit = func(n int) { exitCalled = true; exitCode = n }
 
+	// strict variables
+	stdin = bytes.NewBufferString(src)
+	buf = &bytes.Buffer{}
+	stderr = buf
+	os.Args = []string{"liquid", "--strict"}
+	main()
+	require.True(t, exitCalled)
+	require.Equal(t, 1, exitCode)
+	require.Equal(t, "Liquid error: undefined variable in {{ TARGET }}\n", buf.String())
+
+	exitCode = 0
 	os.Args = []string{"liquid", "testdata/source.liquid"}
 	main()
 	require.Equal(t, 0, exitCode)

--- a/engine.go
+++ b/engine.go
@@ -66,6 +66,11 @@ func (e *Engine) RegisterTag(name string, td Renderer) {
 	})
 }
 
+// StrictVariables causes the renderer to error when the template contains an undefined variable.
+func (e *Engine) StrictVariables() {
+	e.cfg.StrictVariables = true
+}
+
 // ParseTemplate creates a new Template using the engine configuration.
 func (e *Engine) ParseTemplate(source []byte) (*Template, SourceError) {
 	return newTemplate(&e.cfg, source, "", 0)

--- a/render/config.go
+++ b/render/config.go
@@ -8,7 +8,8 @@ import (
 type Config struct {
 	parser.Config
 	grammar
-	Cache map[string][]byte
+	Cache           map[string][]byte
+	StrictVariables bool
 }
 
 type grammar struct {

--- a/render/render.go
+++ b/render/render.go
@@ -2,6 +2,7 @@
 package render
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -65,6 +66,9 @@ func (n *ObjectNode) render(w *trimWriter, ctx nodeContext) Error {
 	value, err := ctx.Evaluate(n.expr)
 	if err != nil {
 		return wrapRenderError(err, n)
+	}
+	if value == nil && ctx.config.StrictVariables {
+		return wrapRenderError(errors.New("undefined variable"), n)
 	}
 	if err := wrapRenderError(writeObject(w, value), n); err != nil {
 		return err


### PR DESCRIPTION
The Ruby implementation has support for erroring when a template has an undefined variable. This is implemented by passing an option to the render() method.

As this version doesn't expose render.Config in the engine, a StrictVariables() method is provided on the engine to enable it. This differs from the Ruby version in that it's on for the entire engine, rather than enabled for each call to Render(). This is more similar to the Ruby version's render!() method as it immediately errors, rather than storing a stack of errors which can be accessed later.

Refs. #8

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
