### PR TITLE
Bug fixes for WrapError(), Errorf() and SourceFile() in a block context

### DIFF
--- a/render/context_test.go
+++ b/render/context_test.go
@@ -68,6 +68,11 @@ func addContextTestTags(s Config) {
 			return c.WrapError(errors.New("giftwrapped"))
 		}, nil
 	})
+	s.AddBlock("test_block_errorf").Compiler(func(c BlockNode) (func(w io.Writer, c Context) error, error) {
+		return func(w io.Writer, c Context) error {
+			return c.Errorf("giftwrapped")
+		}, nil
+	})
 }
 
 var contextTests = []struct{ in, out string }{
@@ -88,6 +93,7 @@ var contextErrorTests = []struct{ in, expect string }{
 	{`{% test_render_file testdata/render_file_syntax_error.txt %}`, "syntax error"},
 	{`{% test_render_file testdata/render_file_runtime_error.txt %}`, "undefined tag"},
 	{`{% test_block_wraperror %}{% endtest_block_wraperror %}`, "giftwrapped"},
+	{`{% test_block_errorf %}{% endtest_block_errorf %}`, "giftwrapped"},
 }
 
 var contextTestBindings = map[string]interface{}{


### PR DESCRIPTION
## Checklist

- [X] I have read the contribution guidelines.
- [X] `make test` passes.
- [ ] `make lint` passes.
- [X] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.

Fixes #80 