### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,18 +10,18 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ Contributors: @osteele, @thessem
   ([08cf333](https://github.com/osteele/liquid/commit/08cf333))
 * Consolidate {expressions,values}/drops.go
   ([516182a](https://github.com/osteele/liquid/commit/516182a))
-* Document values, includng new struct behavior
+* Document values, including new struct behavior
   ([1bc9726](https://github.com/osteele/liquid/commit/1bc9726))
 * Fix struct PropertyValue attempting to use an invalid pointer
   ([b2f5f1f](https://github.com/osteele/liquid/commit/b2f5f1f))


### PR DESCRIPTION
This PR bumps GitHub workflow actions to latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/osteele/liquid/actions/runs/8846283387).

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.