### PR TITLE
Fix whitespace control

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -46,6 +46,20 @@ type ASTSeq struct {
 	sourcelessNode
 }
 
+// TrimDirection determines the trim direction of an ASTTrim object.
+type TrimDirection int
+
+const (
+	Left TrimDirection = iota
+	Right
+)
+
+// ASTTrim is a trim object.
+type ASTTrim struct {
+	sourcelessNode
+	TrimDirection
+}
+
 // It shouldn't be possible to get an error from one of these node types.
 // If it is, this needs to be re-thought to figure out where the source
 // location comes from.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -96,6 +96,10 @@ func (c Config) parseTokens(tokens []Token) (ASTNode, Error) { // nolint: gocycl
 			} else {
 				*ap = append(*ap, &ASTTag{tok})
 			}
+		case tok.Type == TrimLeftTokenType:
+			*ap = append(*ap, &ASTTrim{TrimDirection: Left})
+		case tok.Type == TrimRightTokenType:
+			*ap = append(*ap, &ASTTrim{TrimDirection: Right})
 		}
 	}
 	if bn != nil {

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -27,28 +27,43 @@ func Scan(data string, loc SourceLoc, delims []string) (tokens []Token) {
 		source := data[ts:te]
 		switch {
 		case data[ts:ts+len(delims[0])] == delims[0]:
-			tok := Token{
+			if source[2] == '-' {
+				tokens = append(tokens, Token{
+					Type: TrimLeftTokenType,
+				})
+			}
+			tokens = append(tokens, Token{
 				Type:      ObjTokenType,
 				SourceLoc: loc,
 				Source:    source,
 				Args:      data[m[2]:m[3]],
-				TrimLeft:  source[2] == '-',
-				TrimRight: source[len(source)-3] == '-',
+			})
+			if source[len(source)-3] == '-' {
+				tokens = append(tokens, Token{
+					Type: TrimRightTokenType,
+				})
 			}
-			tokens = append(tokens, tok)
 		case data[ts:ts+len(delims[2])] == delims[2]:
+			if source[2] == '-' {
+				tokens = append(tokens, Token{
+					Type: TrimLeftTokenType,
+				})
+			}
 			tok := Token{
 				Type:      TagTokenType,
 				SourceLoc: loc,
 				Source:    source,
 				Name:      data[m[4]:m[5]],
-				TrimLeft:  source[2] == '-',
-				TrimRight: source[len(source)-3] == '-',
 			}
 			if m[6] > 0 {
 				tok.Args = data[m[6]:m[7]]
 			}
 			tokens = append(tokens, tok)
+			if source[len(source)-3] == '-' {
+				tokens = append(tokens, Token{
+					Type: TrimRightTokenType,
+				})
+			}
 		}
 		loc.LineNo += strings.Count(source, "\n")
 		p = te

--- a/parser/token.go
+++ b/parser/token.go
@@ -4,12 +4,11 @@ import "fmt"
 
 // A Token is an object {{ a.b }}, a tag {% if a>b %}, or a text chunk (anything outside of {{}} and {%%}.)
 type Token struct {
-	Type                TokenType
-	SourceLoc           SourceLoc
-	Name                string // Name is the tag name of a tag Chunk. E.g. the tag name of "{% if 1 %}" is "if".
-	Args                string // Parameters is the tag arguments of a tag Chunk. E.g. the tag arguments of "{% if 1 %}" is "1".
-	Source              string // Source is the entirety of the token, including the "{{", "{%", etc. markers.
-	TrimLeft, TrimRight bool   // Trim whitespace left or right of this token; from {{- tag -}} and {%- expr -%}
+	Type      TokenType
+	SourceLoc SourceLoc
+	Name      string // Name is the tag name of a tag Chunk. E.g. the tag name of "{% if 1 %}" is "if".
+	Args      string // Parameters is the tag arguments of a tag Chunk. E.g. the tag arguments of "{% if 1 %}" is "1".
+	Source    string // Source is the entirety of the token, including the "{{", "{%", etc. markers.
 }
 
 // TokenType is the type of a Chunk
@@ -24,6 +23,10 @@ const (
 	TagTokenType
 	// ObjTokenType is the type of an object Chunk "{{…}}"
 	ObjTokenType
+	// TrimLeftTokenType is the type of a left trim tag "-"
+	TrimLeftTokenType
+	// TrimRightTokenType is the type of a right trim tag "-"
+	TrimRightTokenType
 )
 
 // SourceLoc contains a Token's source location. Pathname is in the local file
@@ -53,6 +56,8 @@ func (c Token) String() string {
 		return fmt.Sprintf("%v{Tag:%#v, Args:%#v}", c.Type, c.Name, c.Args)
 	case ObjTokenType:
 		return fmt.Sprintf("%v{%#v}", c.Type, c.Args)
+	case TrimLeftTokenType, TrimRightTokenType:
+		return "-"
 	default:
 		return fmt.Sprintf("%v{%#v}", c.Type, c.Source)
 	}

--- a/render/compiler.go
+++ b/render/compiler.go
@@ -66,6 +66,8 @@ func (c Config) compileNode(n parser.ASTNode) (Node, parser.Error) {
 		return &TextNode{n.Token}, nil
 	case *parser.ASTObject:
 		return &ObjectNode{n.Token, n.Expr}, nil
+	case *parser.ASTTrim:
+		return &TrimNode{TrimDirection: n.TrimDirection}, nil
 	default:
 		panic(fmt.Errorf("un-compilable node type %T", n))
 	}

--- a/render/nodes.go
+++ b/render/nodes.go
@@ -51,6 +51,12 @@ type SeqNode struct {
 	sourcelessNode
 }
 
+// TrimNode is a trim object.
+type TrimNode struct {
+	sourcelessNode
+	parser.TrimDirection
+}
+
 // FIXME requiring this is a bad design
 type sourcelessNode struct{}
 

--- a/render/render.go
+++ b/render/render.go
@@ -4,6 +4,7 @@ package render
 import (
 	"errors"
 	"fmt"
+	"github.com/osteele/liquid/parser"
 	"io"
 	"reflect"
 	"time"
@@ -17,21 +18,24 @@ func Render(node Node, w io.Writer, vars map[string]interface{}, c Config) Error
 	if err := node.render(&tw, newNodeContext(vars, c)); err != nil {
 		return err
 	}
-	if err := tw.Flush(); err != nil {
+	if _, err := tw.Flush(); err != nil {
 		panic(err)
 	}
 	return nil
 }
 
-// RenderASTSequence renders a sequence of nodes.
+// RenderSequence renders a sequence of nodes.
 func (c nodeContext) RenderSequence(w io.Writer, seq []Node) Error {
-	tw := trimWriter{w: w}
+	tw, ok := w.(*trimWriter)
+	if !ok {
+		tw = &trimWriter{w: w}
+	}
 	for _, n := range seq {
-		if err := n.render(&tw, c); err != nil {
+		if err := n.render(tw, c); err != nil {
 			return err
 		}
 	}
-	if err := tw.Flush(); err != nil {
+	if _, err := tw.Flush(); err != nil {
 		panic(err)
 	}
 	return nil
@@ -47,9 +51,7 @@ func (n *BlockNode) render(w *trimWriter, ctx nodeContext) Error {
 	if renderer == nil {
 		panic(fmt.Errorf("unset renderer for %v", n))
 	}
-	w.TrimLeft(n.TrimLeft)
 	err := renderer(w, rendererContext{ctx, nil, n})
-	w.TrimRight(n.TrimRight)
 	return wrapRenderError(err, n)
 }
 
@@ -64,7 +66,6 @@ func (n *RawNode) render(w *trimWriter, ctx nodeContext) Error {
 }
 
 func (n *ObjectNode) render(w *trimWriter, ctx nodeContext) Error {
-	w.TrimLeft(n.TrimLeft)
 	value, err := ctx.Evaluate(n.expr)
 	if err != nil {
 		return wrapRenderError(err, n)
@@ -75,7 +76,6 @@ func (n *ObjectNode) render(w *trimWriter, ctx nodeContext) Error {
 	if err := wrapRenderError(writeObject(w, value), n); err != nil {
 		return err
 	}
-	w.TrimRight(n.TrimRight)
 	return nil
 }
 
@@ -89,15 +89,22 @@ func (n *SeqNode) render(w *trimWriter, ctx nodeContext) Error {
 }
 
 func (n *TagNode) render(w *trimWriter, ctx nodeContext) Error {
-	w.TrimLeft(n.TrimLeft)
 	err := wrapRenderError(n.renderer(w, rendererContext{ctx, n, nil}), n)
-	w.TrimRight(n.TrimRight)
 	return err
 }
 
-func (n *TextNode) render(w *trimWriter, ctx nodeContext) Error {
+func (n *TextNode) render(w *trimWriter, _ nodeContext) Error {
 	_, err := io.WriteString(w, n.Source)
 	return wrapRenderError(err, n)
+}
+
+func (n *TrimNode) render(w *trimWriter, _ nodeContext) Error {
+	if n.TrimDirection == parser.Left {
+		return wrapRenderError(w.TrimLeft(), n)
+	} else {
+		w.TrimRight()
+		return nil
+	}
 }
 
 // writeObject writes a value used in an object node


### PR DESCRIPTION
## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.

Instead of keeping trimming flags on all tokens, introduce explicit trim tokens: `TrimLeftTokenType` and `TrimRightTokenType`, `trimWriter` configuration is then triggere via `(n *TrimNode) render`. 
