### PR TITLE
patch: add nil check for grammer field before g.BlockSyntax call

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -57,6 +57,9 @@ func (c Config) parseTokens(tokens []Token) (ASTNode, Error) { // nolint: gocycl
 		case tok.Type == TextTokenType:
 			*ap = append(*ap, &ASTText{Token: tok})
 		case tok.Type == TagTokenType:
+			if g == nil {
+				return nil, Errorf(tok, "Grammer field is nil")
+			}
 			if cs, ok := g.BlockSyntax(tok.Name); ok {
 				switch {
 				case tok.Name == "comment":


### PR DESCRIPTION
## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
