### PR TITLE
Add a NewBasicEngine function

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -21,6 +21,11 @@ func NewEngine() *Engine {
 	return &e
 }
 
+// NewBasicEngine returns a new Engine without the standard filters or tags.
+func NewBasicEngine() *Engine {
+	return &Engine{render.NewConfig()}
+}
+
 // RegisterBlock defines a block e.g. {% tag %}…{% endtag %}.
 func (e *Engine) RegisterBlock(name string, td Renderer) {
 	e.cfg.AddBlock(name).Renderer(func(w io.Writer, ctx render.Context) error {

--- a/engine_test.go
+++ b/engine_test.go
@@ -40,6 +40,25 @@ func TestEngine_ParseAndRenderString(t *testing.T) {
 	}
 }
 
+func TestBasicEngine_ParseAndRenderString(t *testing.T) {
+	engine := NewBasicEngine()
+
+	t.Run("1", func(t *testing.T) {
+		test := liquidTests[0]
+		out, err := engine.ParseAndRenderString(test.in, testBindings)
+		require.NoErrorf(t, err, test.in)
+		require.Equalf(t, test.expected, out, test.in)
+	})
+
+	for i, test := range liquidTests[1:] {
+		t.Run(strconv.Itoa(i+2), func(t *testing.T) {
+			out, err := engine.ParseAndRenderString(test.in, testBindings)
+			require.Errorf(t, err, test.in)
+			require.Equalf(t, "", out, test.in)
+		})
+	}
+}
+
 type capWriter struct {
 	bytes.Buffer
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.

This PR follows up [this issue](https://github.com/osteele/liquid/issues/102) I raised recently.

I'd like to add new function to create a "basic" liquid engine which provides an instance of the liquid engine without the standard filters or tags registered. This would allow the developer to still render variables in a liquid template, but only use tags and filter they wish to register.