### PR TITLE
fix: size property val

### DIFF
--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/osteele/liquid/expressions"
+
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 var filterTests = []struct {
@@ -79,6 +79,8 @@ var filterTests = []struct {
 	{`"2017-07-09" | date: "%d/%m"`, "09/07"},
 	{`"2017-07-09" | date: "%e/%m"`, " 9/07"},
 	{`"2017-07-09" | date: "%-d/%-m"`, "9/7"},
+	{`1730040524 | date: "%b %d, %y"`, "Oct 27, 24"},
+	{`"1730040524" | date: "%b %d, %y"`, "Oct 27, 24"},
 
 	// sequence (array or string) filters
 	{`"Ground control to Major Tom." | size`, 28},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osteele/liquid
 
-go 1.22
+go 1.21
 
 require (
 	github.com/osteele/tuesday v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osteele/liquid
 
-go 1.21
+go 1.22
 
 require (
 	github.com/osteele/tuesday v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osteele/liquid
 
-go 1.23
+go 1.22
 
 require (
 	github.com/osteele/tuesday v1.0.3

--- a/values/parsedate.go
+++ b/values/parsedate.go
@@ -2,7 +2,9 @@ package values
 
 import (
 	"reflect"
+	"strconv"
 	"time"
+	"unicode"
 )
 
 var zeroTime time.Time
@@ -49,6 +51,14 @@ func ParseDate(s string) (time.Time, error) {
 	if s == "now" {
 		return time.Now(), nil
 	}
+	// Parse potentially Unix timestamps.
+	if isOnlyNumbers(s) {
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return time.Unix(i, 0), nil
+	}
 	for _, layout := range dateLayouts {
 		t, err := time.ParseInLocation(layout, s, time.Local)
 		if err == nil {
@@ -56,4 +66,13 @@ func ParseDate(s string) (time.Time, error) {
 		}
 	}
 	return zeroTime, conversionError("", s, reflect.TypeOf(zeroTime))
+}
+
+func isOnlyNumbers(s string) bool {
+	for _, c := range s {
+		if !unicode.IsDigit(c) {
+			return false
+		}
+	}
+	return true
 }

--- a/values/parsedate_test.go
+++ b/values/parsedate_test.go
@@ -2,6 +2,7 @@ package values
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -14,4 +15,8 @@ func TestConstant(t *testing.T) {
 	dt, err = ParseDate("2017-07-09 10:40:00 UTC")
 	require.NoError(t, err)
 	require.Equal(t, timeMustParse("2017-07-09T10:40:00Z"), dt)
+
+	dt, err = ParseDate("1730040524")
+	require.NoError(t, err)
+	require.Equal(t, timeMustParse("2024-10-27T14:48:44Z"), dt.In(time.UTC))
 }

--- a/values/value.go
+++ b/values/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -226,7 +227,7 @@ func (sv stringValue) Contains(substr Value) bool {
 
 func (sv stringValue) PropertyValue(iv Value) Value {
 	if iv.Interface() == sizeKey {
-		return ValueOf(len(sv.value.(string)))
+		return ValueOf(utf8.RuneCountInString(sv.value.(string)))
 	}
 	return nilValue
 }


### PR DESCRIPTION
It counts bytes currently, not characters (important for WU, who like to do conditionals based on SMS character count).

Note: I do not need to fix this for the `| size` filter, because the [bug doesn't exist there](https://github.com/messagebird-dev/liquid/blob/fix/size-property-val/values/arrays.go#L20).
