### PR TITLE
Implemented auto-escape functionality and provided a default escape replacer for HTML.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -148,3 +148,11 @@ func (e *Engine) ParseTemplateAndCache(source []byte, path string, line int) (*T
 	e.cfg.Cache[path] = source
 	return t, err
 }
+
+// SetAutoEscapeReplacer enables auto-escape functionality where the output of expression blocks ({{ ... }}) is
+// passed though a render.Replacer during rendering, unless it's been marked as safe by applying the 'safe' filter.
+// This filter is automatically registered when this method is called. The filter must be applied last.
+// A replacer is provided for escaping HTML (see render.HtmlEscaper).
+func (e *Engine) SetAutoEscapeReplacer(replacer render.Replacer) {
+	e.cfg.SetAutoEscapeReplacer(replacer)
+}

--- a/render/autoescape.go
+++ b/render/autoescape.go
@@ -1,0 +1,21 @@
+package render
+
+import (
+	"io"
+	"strings"
+)
+
+// HtmlEscaper is a Replacer that escapes HTML markup characters. Copied from Go standard library because it's
+// not exposed.
+var HtmlEscaper = strings.NewReplacer(
+	`&`, "&amp;",
+	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	`<`, "&lt;",
+	`>`, "&gt;",
+	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
+)
+
+// Replacer interface is used for auto-escape.
+type Replacer interface {
+	WriteString(io.Writer, string) (int, error)
+}

--- a/render/autoescape_test.go
+++ b/render/autoescape_test.go
@@ -1,0 +1,75 @@
+package render
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/osteele/liquid/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderEscapeFilter(t *testing.T) {
+	cfg := NewConfig()
+	cfg.SetAutoEscapeReplacer(HtmlEscaper)
+	buf := new(bytes.Buffer)
+
+	f := func(t *testing.T, tmpl string, bindings map[string]interface{}, out string) {
+		t.Helper()
+		buf.Reset()
+		root, err := cfg.Compile(tmpl, parser.SourceLoc{})
+		require.NoError(t, err)
+		err = Render(root, buf, bindings, cfg)
+		require.NoError(t, err)
+		require.Equal(t, out, buf.String())
+	}
+
+	t.Run("unsafe", func(t *testing.T) {
+		f(t,
+			`{{ input }}`,
+			map[string]interface{}{
+				"input": "<script>doEvilStuff()</script>",
+			},
+			"&lt;script&gt;doEvilStuff()&lt;/script&gt;",
+		)
+	})
+
+	t.Run("safe", func(t *testing.T) {
+		f(t,
+			`{{ input|safe }}`,
+			map[string]interface{}{
+				"input": "<script>doGoodStuff()</script>",
+			},
+			"<script>doGoodStuff()</script>",
+		)
+	})
+
+	t.Run("double safe", func(t *testing.T) {
+		f(t,
+			`{{ input|safe|safe }}`,
+			map[string]interface{}{
+				"input": "<script>doGoodStuff()</script>",
+			},
+			"<script>doGoodStuff()</script>",
+		)
+	})
+
+	t.Run("unsafe slice result", func(t *testing.T) {
+		f(t,
+			`{{ input }}`,
+			map[string]interface{}{
+				"input": []interface{}{"<a>", "<b>"},
+			},
+			"&lt;a&gt;&lt;b&gt;",
+		)
+	})
+
+	t.Run("safe slice result", func(t *testing.T) {
+		f(t,
+			`{{ input|safe }}`,
+			map[string]interface{}{
+				"input": []interface{}{"<a>", "<b>"},
+			},
+			"<a><b>",
+		)
+	})
+}

--- a/render/config.go
+++ b/render/config.go
@@ -11,6 +11,8 @@ type Config struct {
 	Cache           map[string][]byte
 	StrictVariables bool
 	TemplateStore   TemplateStore
+
+	escapeReplacer Replacer
 }
 
 type grammar struct {
@@ -31,4 +33,9 @@ func NewConfig() Config {
 		Cache:         map[string][]byte{},
 		TemplateStore: &FileTemplateStore{},
 	}
+}
+
+func (c *Config) SetAutoEscapeReplacer(replacer Replacer) {
+	c.escapeReplacer = replacer
+	c.AddSafeFilter()
 }

--- a/values/value.go
+++ b/values/value.go
@@ -230,3 +230,9 @@ func (sv stringValue) PropertyValue(iv Value) Value {
 	}
 	return nilValue
 }
+
+// SafeValue is a wrapped interface{} to mark it as being safe so that auto-escape is not applied.
+// It is used by the 'safe' filter which is added when (*Engine).SetAutoEscapeReplacer() is called.
+type SafeValue struct {
+	Value interface{}
+}


### PR DESCRIPTION

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
