### PR TITLE
Incomplete session description provided

### DIFF
--- a/engine_examples_test.go
+++ b/engine_examples_test.go
@@ -288,3 +288,20 @@ func TestUnicodeEdgeCases(t *testing.T) {
 		require.Equal(t, "HELLO WORLD", string(result))
 	})
 }
+
+// TestIssue63_UnicodeVariableNames tests that Unicode variable names work correctly
+// See: https://github.com/osteele/liquid/issues/63
+func TestIssue63_UnicodeVariableNames(t *testing.T) {
+	t.Run("ExactIssue63Example", func(t *testing.T) {
+		// This is the exact example from issue #63 that was failing
+		vars := map[string]any{
+			"描述": "content",
+		}
+
+		template := NewEngine()
+		result, err := template.ParseAndRender([]byte("{{ 描述 }}"), vars)
+
+		require.NoError(t, err)
+		require.Equal(t, "content", string(result))
+	})
+}


### PR DESCRIPTION
This test verifies that Unicode variable names, specifically the Chinese variable '描述' mentioned in issue #63, now work correctly after the fix in PR #116 which added Unicode identifier support.

The test uses the exact example from the issue report to ensure the previously failing case now passes.

Refs #63

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
