### PR TITLE
Enhance slice filter with Unicode support and array slicing (#72)

### DIFF
--- a/filters/standard_filters_test.go
+++ b/filters/standard_filters_test.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,7 +113,24 @@ Liquid" | slice: 0`, "L"},
 Liquid" | slice: 2, 4`, "quid"},
 	{`"Liquid" | slice: -3, 2`, "ui"},
 	{`"" | slice: 1`, ""},
-	{`"Liquid" | slice: -7`, ""},
+	{`"Liquid" | slice: 2, 100`, "quid"},
+	{`"Liquid" | slice: 100`, ""},
+	{`"Liquid" | slice: 100, 200`, ""},
+	{`"Liquid" | slice: -100`, "L"},
+	{`"Liquid" | slice: -100, 200`, "Liquid"},
+	{`"白鵬翔" | slice: 0`, "白"},
+	{`"白鵬翔" | slice: 1`, "鵬"},
+	{`"白鵬翔" | slice: 2`, "翔"},
+	{`"白鵬翔" | slice: 0, 2`, "白鵬"},
+	{`"白鵬翔" | slice: 1, 2`, "鵬翔"},
+	{`"白鵬翔" | slice: 100, 200`, ""},
+	{`"白鵬翔" | slice: -100`, "白"},
+	{`"白鵬翔" | slice: -100, 200`, "白鵬翔"},
+	{`">` + strings.Repeat(".", 10000) + `<" | slice: 1, 10000`, strings.Repeat(".", 10000)},
+	{`"a,b,c" | split: "," | slice: -1 | join`, "c"},
+	{`"a,b,c" | split: "," | slice: 1, 1 | join`, "b"},
+	{`"a,b,c" | split: "," | slice: 0, 2 | join`, "a b"},
+	{`"a,b,c" | split: "," | slice: 1, 2 | join`, "b c"},
 
 	{`"a/b/c" | split: '/' | join: '-'`, "a-b-c"},
 	{`"a/b/" | split: '/' | join: '-'`, "a-b"},


### PR DESCRIPTION
- Add proper Unicode handling using runes instead of regex
- Fix performance issues with strings longer than 1000 characters
- Add support for slicing arrays/slices, not just strings
- Improve bounds checking: clamp out-of-bounds negative indices to 0
- Add comprehensive test coverage:
  - Unicode strings (Japanese characters)
  - Very long strings (10,000+ characters)
  - Out-of-bounds indices (positive and negative)
  - Array slicing from split operations


Resolves #72

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
