### PR TITLE
Implement OR operator

### DIFF
--- a/expressions/expressions.y
+++ b/expressions/expressions.y
@@ -84,6 +84,7 @@ exprs: expr expr2 { $$ = append([]Expression{&expression{$1}}, $2...) } ;
 expr2:
   /* empty */    { $$ = []Expression{} }
 | ',' expr expr2 { $$ = append([]Expression{&expression{$2}}, $3...) }
+| OR expr expr2  { $$ = append([]Expression{&expression{$2}}, $3...) }
 ;
 
 string: LITERAL {

--- a/expressions/statements_test.go
+++ b/expressions/statements_test.go
@@ -42,4 +42,8 @@ func TestParseStatement(t *testing.T) {
 	stmt, err = ParseStatement(WhenStatementSelector, "a, b")
 	require.NoError(t, err)
 	require.Len(t, stmt.Exprs, 2)
+
+	stmt, err = ParseStatement(WhenStatementSelector, "a or b")
+	require.NoError(t, err)
+	require.Len(t, stmt.Exprs, 2)
 }

--- a/expressions/y.go
+++ b/expressions/y.go
@@ -101,54 +101,55 @@ var yyExca = [...]int8{
 
 const yyPrivate = 57344
 
-const yyLast = 120
+const yyLast = 123
 
 var yyAct = [...]int8{
-	9, 50, 45, 19, 8, 2, 79, 24, 14, 15,
-	10, 11, 46, 35, 3, 4, 5, 6, 36, 26,
-	10, 11, 49, 63, 26, 44, 46, 47, 54, 55,
-	56, 57, 58, 59, 60, 61, 26, 12, 42, 26,
-	25, 27, 48, 40, 80, 64, 27, 12, 65, 68,
-	66, 41, 69, 67, 71, 22, 14, 15, 27, 72,
-	51, 27, 39, 73, 74, 14, 15, 17, 75, 76,
-	20, 78, 1, 13, 7, 81, 82, 77, 21, 26,
-	83, 52, 53, 84, 28, 29, 32, 33, 16, 37,
-	38, 34, 62, 43, 18, 31, 30, 26, 23, 70,
-	0, 27, 28, 29, 32, 33, 0, 0, 0, 34,
-	0, 0, 0, 31, 30, 0, 0, 0, 0, 27,
+	9, 50, 45, 19, 2, 8, 82, 24, 14, 15,
+	10, 11, 46, 35, 10, 11, 26, 36, 3, 4,
+	5, 6, 49, 64, 26, 44, 46, 47, 55, 56,
+	57, 58, 59, 60, 61, 62, 26, 12, 27, 74,
+	40, 12, 25, 42, 65, 26, 27, 7, 66, 69,
+	67, 48, 70, 71, 68, 73, 52, 41, 27, 39,
+	22, 83, 37, 38, 75, 17, 51, 27, 20, 77,
+	78, 1, 80, 81, 84, 85, 14, 15, 53, 54,
+	79, 21, 26, 86, 76, 16, 87, 28, 29, 32,
+	33, 43, 18, 23, 34, 63, 72, 0, 31, 30,
+	26, 14, 15, 0, 27, 28, 29, 32, 33, 13,
+	0, 0, 34, 0, 0, 0, 31, 30, 0, 0,
+	0, 0, 27,
 }
 
 var yyPact = [...]int16{
-	6, -1000, 48, 62, 66, 50, 16, -1000, 18, 90,
-	-1000, -1000, 16, -1000, 16, 16, 36, 44, 13, -2,
-	-1000, 2, 26, -3, 32, 76, -1000, 16, 16, 16,
-	16, 16, 16, 16, 16, 72, -9, -1000, -1000, 16,
-	-1000, -1000, -1000, -1000, 66, -1000, 66, -1000, 16, -1000,
-	-1000, 16, -1000, 16, 29, 17, 17, 17, 17, 17,
-	17, 17, 16, -1000, 39, -16, -16, 18, 17, 32,
-	-22, 17, -1000, 12, -1000, -1000, -1000, 70, -1000, 16,
-	-1000, -1000, 16, 17, 17,
+	10, -1000, 84, 60, 64, 55, 6, -1000, 20, 93,
+	-1000, -1000, 6, -1000, 6, 6, 33, 50, 18, -2,
+	-1000, 2, 35, -3, 38, 73, -1000, 6, 6, 6,
+	6, 6, 6, 6, 6, 75, -9, -1000, -1000, 6,
+	-1000, -1000, -1000, -1000, 64, -1000, 64, -1000, 6, -1000,
+	-1000, 6, 6, -1000, 6, 9, 17, 17, 17, 17,
+	17, 17, 17, 6, -1000, 59, -16, -16, 20, 17,
+	38, 38, -22, 17, -1000, 29, -1000, -1000, -1000, 69,
+	-1000, -1000, 6, -1000, -1000, 6, 17, 17,
 }
 
 var yyPgo = [...]int8{
-	0, 0, 74, 4, 5, 99, 98, 1, 94, 93,
-	2, 88, 78, 77, 3, 72,
+	0, 0, 47, 5, 4, 96, 93, 1, 92, 91,
+	2, 85, 81, 80, 3, 71,
 }
 
 var yyR1 = [...]int8{
 	0, 15, 15, 15, 15, 15, 11, 11, 11, 8,
-	9, 9, 10, 10, 6, 7, 7, 14, 12, 13,
-	13, 13, 1, 1, 1, 1, 1, 1, 3, 3,
-	3, 5, 5, 2, 2, 2, 2, 2, 2, 2,
-	2, 4, 4, 4,
+	9, 9, 10, 10, 6, 7, 7, 7, 14, 12,
+	13, 13, 13, 1, 1, 1, 1, 1, 1, 3,
+	3, 3, 5, 5, 2, 2, 2, 2, 2, 2,
+	2, 2, 4, 4, 4,
 }
 
 var yyR2 = [...]int8{
 	0, 2, 5, 3, 3, 3, 1, 2, 2, 2,
-	3, 1, 0, 3, 2, 0, 3, 1, 4, 0,
-	2, 3, 1, 1, 2, 4, 5, 3, 1, 3,
-	4, 1, 3, 1, 3, 3, 3, 3, 3, 3,
-	3, 1, 3, 3,
+	3, 1, 0, 3, 2, 0, 3, 3, 1, 4,
+	0, 2, 3, 1, 1, 2, 4, 5, 3, 1,
+	3, 4, 1, 3, 1, 3, 3, 3, 3, 3,
+	3, 3, 1, 3, 3,
 }
 
 var yyChk = [...]int16{
@@ -157,22 +158,22 @@ var yyChk = [...]int16{
 	4, -12, 5, -6, -1, 22, 7, 29, 12, 13,
 	24, 23, 14, 15, 19, -1, -4, -2, -2, 26,
 	7, 7, 25, -9, 27, -10, 28, 25, 16, 25,
-	-7, 28, 5, 6, -1, -1, -1, -1, -1, -1,
-	-1, -1, 20, 32, -4, -14, -14, -3, -1, -1,
-	-5, -1, 30, -1, 25, -10, -10, -13, -7, 28,
-	32, 5, 6, -1, -1,
+	-7, 28, 18, 5, 6, -1, -1, -1, -1, -1,
+	-1, -1, -1, 20, 32, -4, -14, -14, -3, -1,
+	-1, -1, -5, -1, 30, -1, 25, -10, -10, -13,
+	-7, -7, 28, 32, 5, 6, -1, -1,
 }
 
 var yyDef = [...]int8{
-	0, -2, 0, 0, 0, 0, 0, 41, 33, 28,
-	22, 23, 0, 1, 0, 0, 0, 6, 0, 12,
-	17, 0, 0, 0, 15, 0, 24, 0, 0, 0,
-	0, 0, 0, 0, 0, 28, 0, 42, 43, 0,
+	0, -2, 0, 0, 0, 0, 0, 42, 34, 29,
+	23, 24, 0, 1, 0, 0, 0, 6, 0, 12,
+	18, 0, 0, 0, 15, 0, 25, 0, 0, 0,
+	0, 0, 0, 0, 0, 29, 0, 43, 44, 0,
 	8, 7, 3, 9, 0, 11, 0, 4, 0, 5,
-	14, 0, 29, 0, 0, 34, 35, 36, 37, 38,
-	39, 40, 0, 27, 0, 12, 12, 19, 28, 15,
-	30, 31, 25, 0, 2, 10, 13, 18, 16, 0,
-	26, 20, 0, 32, 21,
+	14, 0, 0, 30, 0, 0, 35, 36, 37, 38,
+	39, 40, 41, 0, 28, 0, 12, 12, 20, 29,
+	15, 15, 31, 32, 26, 0, 2, 10, 13, 19,
+	16, 17, 0, 27, 21, 0, 33, 22,
 }
 
 var yyTok1 = [...]int8{
@@ -641,8 +642,14 @@ yydefault:
 			yyVAL.exprs = append([]Expression{&expression{yyDollar[2].f}}, yyDollar[3].exprs...)
 		}
 	case 17:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line expressions.y:87
+		{
+			yyVAL.exprs = append([]Expression{&expression{yyDollar[2].f}}, yyDollar[3].exprs...)
+		}
+	case 18:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line expressions.y:89
+//line expressions.y:90
 		{
 			s, ok := yyDollar[1].val.(string)
 			if !ok {
@@ -650,22 +657,22 @@ yydefault:
 			}
 			yyVAL.s = s
 		}
-	case 18:
+	case 19:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line expressions.y:97
+//line expressions.y:98
 		{
 			name, expr, mods := yyDollar[1].name, yyDollar[3].f, yyDollar[4].loopmods
 			yyVAL.loop = Loop{mods, name, &expression{expr}}
 		}
-	case 19:
+	case 20:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line expressions.y:103
+//line expressions.y:104
 		{
 			yyVAL.loopmods = loopModifiers{}
 		}
-	case 20:
+	case 21:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line expressions.y:104
+//line expressions.y:105
 		{
 			switch yyDollar[2].name {
 			case "reversed":
@@ -675,9 +682,9 @@ yydefault:
 			}
 			yyVAL.loopmods = yyDollar[1].loopmods
 		}
-	case 21:
+	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:113
+//line expressions.y:114
 		{
 			switch yyDollar[2].name {
 			case "cols":
@@ -691,71 +698,71 @@ yydefault:
 			}
 			yyVAL.loopmods = yyDollar[1].loopmods
 		}
-	case 22:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line expressions.y:129
-		{
-			val := yyDollar[1].val
-			yyVAL.f = func(Context) values.Value { return values.ValueOf(val) }
-		}
 	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line expressions.y:130
 		{
+			val := yyDollar[1].val
+			yyVAL.f = func(Context) values.Value { return values.ValueOf(val) }
+		}
+	case 24:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line expressions.y:131
+		{
 			name := yyDollar[1].name
 			yyVAL.f = func(ctx Context) values.Value { return values.ValueOf(ctx.Get(name)) }
 		}
-	case 24:
+	case 25:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line expressions.y:131
+//line expressions.y:132
 		{
 			yyVAL.f = makeObjectPropertyExpr(yyDollar[1].f, yyDollar[2].name)
 		}
-	case 25:
+	case 26:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line expressions.y:132
+//line expressions.y:133
 		{
 			yyVAL.f = makeIndexExpr(yyDollar[1].f, yyDollar[3].f)
 		}
-	case 26:
+	case 27:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line expressions.y:133
+//line expressions.y:134
 		{
 			yyVAL.f = makeRangeExpr(yyDollar[2].f, yyDollar[4].f)
 		}
-	case 27:
+	case 28:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:134
+//line expressions.y:135
 		{
 			yyVAL.f = yyDollar[2].f
 		}
-	case 29:
+	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:139
+//line expressions.y:140
 		{
 			yyVAL.f = makeFilter(yyDollar[1].f, yyDollar[3].name, nil)
 		}
-	case 30:
+	case 31:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line expressions.y:140
+//line expressions.y:141
 		{
 			yyVAL.f = makeFilter(yyDollar[1].f, yyDollar[3].name, yyDollar[4].filter_params)
 		}
-	case 31:
+	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line expressions.y:144
+//line expressions.y:145
 		{
 			yyVAL.filter_params = []valueFn{yyDollar[1].f}
 		}
-	case 32:
+	case 33:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:146
+//line expressions.y:147
 		{
 			yyVAL.filter_params = append(yyDollar[1].filter_params, yyDollar[3].f)
 		}
-	case 34:
+	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:150
+//line expressions.y:151
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -763,9 +770,9 @@ yydefault:
 				return values.ValueOf(a.Equal(b))
 			}
 		}
-	case 35:
+	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:157
+//line expressions.y:158
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -773,9 +780,9 @@ yydefault:
 				return values.ValueOf(!a.Equal(b))
 			}
 		}
-	case 36:
+	case 37:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:164
+//line expressions.y:165
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -783,9 +790,9 @@ yydefault:
 				return values.ValueOf(b.Less(a))
 			}
 		}
-	case 37:
+	case 38:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:171
+//line expressions.y:172
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -793,9 +800,9 @@ yydefault:
 				return values.ValueOf(a.Less(b))
 			}
 		}
-	case 38:
+	case 39:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:178
+//line expressions.y:179
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -803,9 +810,9 @@ yydefault:
 				return values.ValueOf(b.Less(a) || a.Equal(b))
 			}
 		}
-	case 39:
+	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:185
+//line expressions.y:186
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
@@ -813,24 +820,24 @@ yydefault:
 				return values.ValueOf(a.Less(b) || a.Equal(b))
 			}
 		}
-	case 40:
+	case 41:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:192
+//line expressions.y:193
 		{
 			yyVAL.f = makeContainsExpr(yyDollar[1].f, yyDollar[3].f)
 		}
-	case 42:
+	case 43:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:197
+//line expressions.y:198
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {
 				return values.ValueOf(fa(ctx).Test() && fb(ctx).Test())
 			}
 		}
-	case 43:
+	case 44:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line expressions.y:203
+//line expressions.y:204
 		{
 			fa, fb := yyDollar[1].f, yyDollar[3].f
 			yyVAL.f = func(ctx Context) values.Value {

--- a/tags/control_flow_tags_test.go
+++ b/tags/control_flow_tags_test.go
@@ -20,10 +20,18 @@ var cfTagTests = []struct{ in, expected string }{
 	// else
 	{`{% case 1 %}{% when 1 %}a{% else %}b{% endcase %}`, "a"},
 	{`{% case 2 %}{% when 1 %}a{% else %}b{% endcase %}`, "b"},
-	// disjunction
+	// disjunction with commas
 	{`{% case 1 %}{% when 1,2 %}a{% else %}b{% endcase %}`, "a"},
 	{`{% case 2 %}{% when 1,2 %}a{% else %}b{% endcase %}`, "a"},
 	{`{% case 3 %}{% when 1,2 %}a{% else %}b{% endcase %}`, "b"},
+	// disjunction with 'or' operator
+	{`{% case 1 %}{% when 1 or 2 %}a{% else %}b{% endcase %}`, "a"},
+	{`{% case 2 %}{% when 1 or 2 %}a{% else %}b{% endcase %}`, "a"},
+	{`{% case 3 %}{% when 1 or 2 %}a{% else %}b{% endcase %}`, "b"},
+	// string values with 'or' operator (matching Shopify docs example)
+	{`{% case 'Love' %}{% when 'Love' or 'Luck' %}potion{% endcase %}`, "potion"},
+	{`{% case 'Luck' %}{% when 'Love' or 'Luck' %}potion{% endcase %}`, "potion"},
+	{`{% case 'Health' %}{% when 'Love' or 'Luck' %}potion{% endcase %}`, ""},
 
 	// if
 	{`{% if true %}true{% endif %}`, "true"},


### PR DESCRIPTION
This commit implements support for the 'or' operator in 'when' clauses of case statements, matching the official Shopify Liquid specification.

Changes:
- Modified expressions.y grammar to accept 'or' as an alternative separator to commas in the expr2 rule for when statements
- Regenerated y.go parser from the updated grammar
- Added comprehensive test cases for 'or' operator usage:
  * Integer values with 'or' operator
  * String values matching Shopify documentation examples
  * Multiple 'or' operators (e.g., 1 or 2 or 3)

The implementation now supports both syntaxes as specified in the Shopify documentation:
- Comma-separated: {% when 1, 2 %}
- OR operator: {% when 1 or 2 %}
- Multiple ORs: {% when 1 or 2 or 3 %}

All existing tests continue to pass, confirming backward compatibility.