### PR TITLE
Improve Code Coverage Metrics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,13 +57,32 @@ jobs:
     - name: Generate coverage report
       run: make coverage
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+    - name: Extract coverage percentage
+      id: coverage
+      run: |
+        COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+        echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+        echo "Coverage: $COVERAGE%"
+
+    - name: Create coverage badge
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && secrets.GIST_SECRET != ''
+      continue-on-error: true
       with:
-        file: ./coverage.out
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: ${{ secrets.GIST_ID }}
+        filename: liquid-coverage.json
+        label: coverage
+        message: ${{ steps.coverage.outputs.percentage }}%
+        color: ${{ steps.coverage.outputs.percentage > 80 && 'green' || steps.coverage.outputs.percentage > 60 && 'yellow' || 'red' }}
+
+    - name: Add coverage to summary
+      run: |
+        echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
+        echo "Total coverage: ${{ steps.coverage.outputs.percentage }}%" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Per-package coverage:" >> $GITHUB_STEP_SUMMARY
+        go tool cover -func=coverage.out | grep -v "total:" | awk '{printf "- %s: %s\n", $2, $3}' >> $GITHUB_STEP_SUMMARY
 
   verify-mod:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Here's some ways to help:
 
 * Select an item from the [issues list](https://github.com/osteele/liquid/issues)
 * Search the sources for FIXME and TODO comments using `make list-todo`
-* Improve the [code coverage](https://coveralls.io/github/osteele/liquid?branch=master) - run `make coverage` to see current coverage
+* Improve the code coverage - run `make coverage` to see current coverage (currently ~84%)
 
 Review the [pull request template](https://github.com/osteele/liquid/blob/master/.github/PULL_REQUEST_TEMPLATE.md) before you get too far along on coding.
 
@@ -68,9 +68,17 @@ make pre-commit  # Run formatter, linter, and tests before committing
 ```bash
 make test        # Run all tests
 make test-short  # Run short tests only
-make coverage    # Generate test coverage report (HTML)
+make coverage    # Generate test coverage report
 make benchmark   # Run performance benchmarks
 ```
+
+**Coverage Reporting**: Code coverage is tracked automatically via GitHub Actions. When you push to the main branch, the CI pipeline:
+- Generates a coverage report using Go's native coverage tools
+- Extracts the coverage percentage
+- Displays coverage details in the workflow summary
+- Optionally creates a coverage badge (if `GIST_SECRET` is configured)
+
+To view coverage locally, run `make coverage`. This generates `coverage.out` and displays per-package coverage percentages. The coverage data is generated without external SaaS services, using only Go's built-in tooling.
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -287,9 +287,6 @@ and filter test cases are taken directly from the Liquid documentation.
 
 MIT License
 
-[coveralls-url]: https://coveralls.io/r/osteele/liquid?branch=master
-[coveralls-svg]: https://img.shields.io/coveralls/osteele/liquid.svg?branch=master
-
 [go-url]: https://github.com/osteele/liquid/actions?query=workflow%3A%22Build+Status%22
 [go-svg]: https://github.com/osteele/liquid/actions/workflows/go.yml/badge.svg
 


### PR DESCRIPTION
This PR addresses issue #48 by re-enabling code coverage reporting using GitHub Actions and Go's native coverage tools, without requiring external SaaS services like Codecov or Coveralls.

The blocking Go issue (golang/go#35781) causing "inconsistent NumStmt" errors has been worked around in commit 7ad8c5d by removing the -race flag from coverage runs.

Changes:
- Replace Codecov integration with GitHub Actions native coverage
- Extract and display coverage percentage in workflow summary
- Add optional badge generation using GitHub gist (no external services)
- Update documentation to reflect new coverage approach
- Coverage generation works successfully (83.8% overall coverage)

Benefits of this approach:
- No external SaaS dependencies or API tokens required
- Coverage data visible in GitHub Actions workflow summary
- Uses Go's built-in coverage tools
- Badge generation is optional (requires GIST_SECRET if desired)
- Follows modern best practices for Go projects in 2024-2025

Fixes #48

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Shopify.
