### PR TITLE
fix: handle 32-bit platform build for uint comparison

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,24 @@ jobs:
     - name: Test
       run: make test
 
+  build-32bit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.26.x
+
+    - name: Build for 32-bit ARM
+      run: GOOS=linux GOARCH=arm GOARM=7 go build ./...
+
+    - name: Build for 32-bit x86
+      run: GOOS=linux GOARCH=386 go build ./...
+
   vet:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **32-bit Platform Build**: Fixed build failure on 32-bit platforms (ARM, x86) where `math.MaxInt64` overflowed `uint` in the `isIntegerType` comparison. The `uint` value is now widened to `uint64` before comparing.
+
+### CI
+
+- Added 32-bit build verification (linux/arm, linux/386) to CI pipeline.
+
 ## 1.8.1 (2026-02-27)
 
 ### Performance

--- a/filters/standard_filters.go
+++ b/filters/standard_filters.go
@@ -36,10 +36,8 @@ func isIntegerType(v any) bool {
 	case int, int8, int16, int32, int64, uint8, uint16, uint32:
 		return true
 	case uint:
-		// Check if uint value fits in int64 range
-		return val <= math.MaxInt64
+		return uint64(val) <= math.MaxInt64
 	case uint64:
-		// Check if uint64 value fits in int64 range
 		return val <= math.MaxInt64
 	default:
 		return false


### PR DESCRIPTION
## Summary
- Fix build failure on 32-bit platforms (ARM, x86) where `math.MaxInt64` overflows `uint`
- Widen `uint` to `uint64` before comparing to `math.MaxInt64` in `isIntegerType`
- Add CI jobs for 32-bit cross-compilation (linux/arm, linux/386)

Fixes #49

## Test plan
- [ ] CI passes on all existing platforms
- [ ] New `build-32bit` CI job passes (linux/arm, linux/386)
- [ ] Existing tests still pass